### PR TITLE
FV2 breaking only works on 10.8; add check and revert to launchd disable

### DIFF
--- a/macdestroyer/README.md
+++ b/macdestroyer/README.md
@@ -1,12 +1,12 @@
 Overview
 ========
 
-macdestroyer is a simple payload-only package that attempts to render the target machine unbootable. It works best with FileVault 2 encrypted volumes.
+macdestroyer is a simple payload-only package that attempts to render the target machine unbootable. It works best on 10.8 systems with FileVault 2 encrypted volumes.
 
 Mechanisms
 ----------
 
-If the machine's local disk is FV2-encrypted:
+On 10.8, if the machine's local disk is FV2-encrypted:
 
 1. Adds a new user called `fde_locked_user` with a random password
 2. Adds this user to the list of users who can unlock the disk
@@ -14,13 +14,13 @@ If the machine's local disk is FV2-encrypted:
 4. Shuts down the machine
 
 
-If not:
+Otherwise:
 
 1. Renames `launchd` to `launchd_disabled`
 2. Shuts down the machine
 
 
-The encrypted case is best when using some sort of FileVault key escrow mechanism, like [Cauliflower Vest](https://github.com/google/cauliflowervest), as this allows for recovery of the disk's data for, e.g., legal discovery.
+The 10.8/encrypted case is best when using some sort of FileVault key escrow mechanism, like [Cauliflower Vest](https://github.com/google/cauliflowervest), as this allows for recovery of the disk's data for, e.g., legal discovery.
 
 The non-FV2 case is, obviously, merely an annoyance to anyone knowledgeable with OS X.
 

--- a/macdestroyer/postflight
+++ b/macdestroyer/postflight
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# Forcibly locks a user out of their machine with no way back in without
-# access to the FileVault recovery key.
+# On 10.8, if the machine is FileVault 2 encrypted, forcibly lock a user out
+# with no way back in without access to the FileVault recovery key.
 #
-# If the machine is not FileVault encrypted, prevent the machine from booting
-# by renaming launchd to launchd_disabled.
+# Otherwise, prevent the machine from booting by renaming launchd to
+# launchd_disabled.
 #
 # Copyright 2014 Google Inc. All rights reserved.
 #
@@ -41,9 +41,12 @@ function check_for_root() {
   fi
 }
 
+function check_for_108() {
+  [[ $(sw_vers -productVersion) == 10.8* ]]
+}
+
 function check_for_filevault() {
-  fdesetup status | grep -q On && return 0
-  return 1
+  fdesetup status | grep -q On
 }
 
 function create_temp_user() {
@@ -78,10 +81,14 @@ function break_machine() {
 function main() {
   check_for_root
 
-  if check_for_filevault; then
-    create_temp_user
-    add_user_to_filevault
-    remove_old_filevault_users
+  if check_for_108; then
+    if check_for_filevault; then
+      create_temp_user
+      add_user_to_filevault
+      remove_old_filevault_users
+    else
+      break_machine
+    fi
   else
     break_machine
   fi


### PR DESCRIPTION
On 10.9 and later, there's no mechanism to add local users via fdesetup without
providing an existing user's password or recovery key. On non-10.8 systems,
fall through to moving launchd out of the way.

Thanks to @rtrouton and @gregneagle for catching this.
