### PR TITLE
fix long formatted string logging, better auth in certs module

### DIFF
--- a/gmacpyutil/gmacpyutil/certs_test.py
+++ b/gmacpyutil/gmacpyutil/certs_test.py
@@ -703,13 +703,13 @@ class CertsModuleTest(mox.MoxTestBase):
     certs.FindCertificates(issuer_cn='i', keychain='k').AndReturn([c])
     certs.logging.debug(
         'Removing cert with fingerprint %s from %s', 'f', 'k').AndReturn(None)
-    certs.DeleteCert('f', certhandler=None,
+    certs.DeleteCert('f', password=None,
                      gui=False, keychain='k').AndReturn(None)
     # Remove fails
     certs.FindCertificates(issuer_cn='i', keychain='k').AndReturn([c])
     certs.logging.debug(
         'Removing cert with fingerprint %s from %s', 'f', 'k').AndReturn(None)
-    certs.DeleteCert('f', certhandler=None,
+    certs.DeleteCert('f', password=None,
                      gui=False, keychain='k').AndRaise(certs.CertError('err'))
     certs.logging.error('Cannot delete old certificate: %s', 'err')
 
@@ -805,9 +805,7 @@ class CertsModuleTest(mox.MoxTestBase):
     self.mox.VerifyAll()
 
   def _SudoContextHelper(self):
-    self.certh = self.mox.CreateMockAnything()
-    self.certh.opener = self.mox.CreateMockAnything()
-    self.certh.opener.password = 'pass'
+    self.password = 'hunter2'
     self.keychain = certs.SYSTEM_KEYCHAIN
 
   def testGetSudoContextWithCertHandler(self):
@@ -816,14 +814,14 @@ class CertsModuleTest(mox.MoxTestBase):
     self.mox.StubOutWithMock(certs.gmacpyutil, 'RunProcess')
     certs.gmacpyutil.RunProcess(
         ['-v'], sudo=True,
-        sudo_password=self.certh.opener.password).AndReturn(['', '', 0])
+        sudo_password=self.password).AndReturn(['', '', 0])
     self.mox.ReplayAll()
     sudo, sudo_pass = certs._GetSudoContext(self.keychain,
                                             gui=True,
-                                            certhandler=self.certh)
+                                            password=self.password)
     self.mox.VerifyAll()
     self.assertTrue(sudo)
-    self.assertEqual(sudo_pass, self.certh.opener.password)
+    self.assertEqual(sudo_pass, 'hunter2')
 
   def testGetSudoContextWithoutCertHandlerGUIError(self):
     self._SudoContextHelper()

--- a/gmacpyutil/gmacpyutil/gmacpyutil.py
+++ b/gmacpyutil/gmacpyutil/gmacpyutil.py
@@ -100,7 +100,7 @@ class MultilineSysLogHandler(logging.handlers.SysLogHandler):
 
       r1 = logging.LogRecord(
           record.name, record.levelno, record.pathname, record.lineno,
-          r1msg, record.args, None, func=record.funcName)
+          r1msg, None, None, func=record.funcName)
       r2 = logging.LogRecord(
           record.name, record.levelno, record.pathname, None, r2msg, None, None)
 

--- a/gmacpyutil/gmacpyutil/gmacpyutil_test.py
+++ b/gmacpyutil/gmacpyutil/gmacpyutil_test.py
@@ -94,6 +94,11 @@ class GmacpytutilModuleTest(mox.MoxTestBase):
     except Exception:  # pylint: disable=broad-except
       gmacpyutil.logging.exception('something is busticated')
 
+  def testMultilineSysLogHandlerFormattedString(self):
+    fs = '%s' +  'a' * 2500
+    gmacpyutil.ConfigureLogging(stderr=False, syslog=True)
+    gmacpyutil.logging.error(fs, 'foo')
+
   def testConfigureLogging(self):
     """Test ConfigureLogging, syslog and stderr, debug log level."""
     self.StubSetup()


### PR DESCRIPTION
We're already formatting the message, so no need to pass on any formatting arguments to the continued line(s)

In certs, simpler auth for GUI environments.