### PR TITLE
Fix keychain minder Makefile

### DIFF
--- a/keychainminder/Package/Makefile
+++ b/keychainminder/Package/Makefile
@@ -3,7 +3,7 @@
 #  Requires TheLuggage (github.com/unixorn/luggage) to be installed.
 #
 
-LUGGAGE:=/usr/local/share/luggage.make
+LUGGAGE:=/usr/local/share/luggage/luggage.make
 include ${LUGGAGE}
 
 TITLE:=KeychainMinder


### PR DESCRIPTION
Correct the LUGGAGE variable to match Luggage's default install location.

https://github.com/unixorn/luggage/blob/master/Makefile#L41