### PR TITLE
[KeychainMinder] Fix update_authdb, update README

### DIFF
--- a/keychainminder/KeychainMinder/Info.plist
+++ b/keychainminder/KeychainMinder/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>CFBundleVersion</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2015 Google Inc. All rights reserved.</string>
 </dict>

--- a/keychainminder/KeychainMinder/update_authdb.py
+++ b/keychainminder/KeychainMinder/update_authdb.py
@@ -67,8 +67,8 @@ def InstallPlugin():
     print 'Mechanism already installed.'
 
   data = _GetRightData(SCREENSAVER_RIGHT)
-  if data.get('rules') != [SCREENSAVER_RULE]:
-    data['rules'] = [SCREENSAVER_RULE]
+  if data.get('rule') != [SCREENSAVER_RULE]:
+    data['rule'] = [SCREENSAVER_RULE]
     _SetRightData(SCREENSAVER_RIGHT, data)
     print 'Screensaver rule updated.'
   else:

--- a/keychainminder/KeychainMinderGUI/Info.plist
+++ b/keychainminder/KeychainMinderGUI/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>CFBundleVersion</key>
-	<string>1.0</string>
+	<string>1.1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/keychainminder/README.md
+++ b/keychainminder/README.md
@@ -36,6 +36,8 @@ been tried. If you find it works, please let us know!
 There's a package Makefile in the Package folder. You'll need
 [TheLuggage](https://github.com/unixorn/luggage) installed to build it.
 
+A reboot is required to take effect at the screensaver.
+
 ## Uninstallation
 
 `sudo /Library/SecurityAgentPlugins/KeychainMinder.bundle/Contents/Resources/uninstall.sh`


### PR DESCRIPTION
update_authdb was looking for a rules array but the array is called rule.
Bump version to 1.1. Update README to mention reboot requirement after install.

Fixes #34 