### PR TITLE
Fix PBDERDecoder

### DIFF
--- a/planb/planb.xcodeproj/project.pbxproj
+++ b/planb/planb.xcodeproj/project.pbxproj
@@ -31,7 +31,7 @@
 
 /* Begin PBXFileReference section */
 		0D6F12DB19EEDD80006B218E /* PBDERDecoder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBDERDecoder.h; sourceTree = "<group>"; };
-		0D6F12DC19EEDD80006B218E /* PBDERDecoder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBDERDecoder.m; sourceTree = "<group>"; };
+		0D6F12DC19EEDD80006B218E /* PBDERDecoder.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = PBDERDecoder.m; sourceTree = "<group>"; tabWidth = 2; };
 		0D789FD819461AC50036F7C4 /* roots.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = roots.pem; sourceTree = "<group>"; };
 		490A51D918D7581B00DA939E /* planb */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = planb; sourceTree = BUILT_PRODUCTS_DIR; };
 		490A51DC18D7581B00DA939E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };

--- a/planb/planb/PBDERDecoder.m
+++ b/planb/planb/PBDERDecoder.m
@@ -81,18 +81,18 @@
  this:
  
  SEQUENCE {
- SET {
- SEQUENCE {
- OBJECT IDENTIFIER (2 5 4 6)
- PrintableString 'US'
- }
- }
- SET {
- SEQUENCE {
- OBJECT IDENTIFIER (2 5 4 10)
- PrintableString 'Megacorp Inc'
- }
- }
+  SET {
+    SEQUENCE {
+      OBJECT IDENTIFIER (2 5 4 6)
+      PrintableString 'US'
+    }
+  }
+  SET {
+    SEQUENCE {
+      OBJECT IDENTIFIER (2 5 4 10)
+      PrintableString 'Megacorp Inc'
+    }
+  }
  }
  
  This method assumes the passed in data will be in that format. If it isn't,

--- a/planb/planb/PBDERDecoder.m
+++ b/planb/planb/PBDERDecoder.m
@@ -79,81 +79,86 @@
 /*
  The DER data provided by NSURLProtectionSpace.distinguishedNames looks like
  this:
-
+ 
  SEQUENCE {
-   SET {
-     SEQUENCE {
-       OBJECT IDENTIFIER (2 5 4 6)
-       PrintableString 'US'
-     }
-   }
-   SET {
-     SEQUENCE {
-       OBJECT IDENTIFIER (2 5 4 10)
-       PrintableString 'Megacorp Inc'
-     }
-   }
+ SET {
+ SEQUENCE {
+ OBJECT IDENTIFIER (2 5 4 6)
+ PrintableString 'US'
  }
-
+ }
+ SET {
+ SEQUENCE {
+ OBJECT IDENTIFIER (2 5 4 10)
+ PrintableString 'Megacorp Inc'
+ }
+ }
+ }
+ 
  This method assumes the passed in data will be in that format. If it isn't,
  the DER decoding will fail and this method will return nil.
-*/
+ */
 - (NSDictionary *)decodeData:(NSData *)data {
   typedef struct {
     SecAsn1Oid oid;
     SecAsn1Item value;
   } OIDKeyValue;
-
+  
   static const SecAsn1Template kOIDValueTemplate[] = {
     { SEC_ASN1_SEQUENCE, 0, NULL, sizeof(OIDKeyValue) },
     { SEC_ASN1_OBJECT_ID, offsetof(OIDKeyValue, oid), NULL, 0 },
     { SEC_ASN1_ANY_CONTENTS, offsetof(OIDKeyValue, value), NULL, 0 },
     { 0, 0, NULL, 0 }
   };
-
+  
   typedef struct {
     OIDKeyValue **vals;
   } OIDKeyValueList;
-
+  
   static const SecAsn1Template kSetOfOIDValueTemplate[] = {
     { SEC_ASN1_SET_OF, 0, kOIDValueTemplate, sizeof(OIDKeyValueList) },
     { 0, 0, NULL, 0 }
   };
-
+  
   typedef struct {
     OIDKeyValueList **lists;
   } OIDKeyValueListSeq;
-
+  
   static const SecAsn1Template kSequenceOfSetOfOIDValueTemplate[] = {
     { SEC_ASN1_SEQUENCE_OF, 0, kSetOfOIDValueTemplate, sizeof(OIDKeyValueListSeq) },
     { 0, 0, NULL, 0 }
   };
-
+  
   OSStatus err = errSecSuccess;
   SecAsn1CoderRef coder;
-
+  
   err = SecAsn1CoderCreate(&coder);
   if (err != errSecSuccess) return nil;
-
+  
   OIDKeyValueListSeq a;
   err = SecAsn1Decode(coder,
                       data.bytes,
                       data.length,
                       kSequenceOfSetOfOIDValueTemplate,
                       &a);
-  SecAsn1CoderRelease(coder);
-  if (err != errSecSuccess) return nil;
-
+  if (err != errSecSuccess) {
+    SecAsn1CoderRelease(coder);
+    return nil;
+  }
+  
   // The data is decoded but now it's in a number of embedded structs.
   // Massage that into a nice dictionary of OID->String pairs.
   NSMutableDictionary *dict = [NSMutableDictionary dictionary];
   OIDKeyValueList *anAttr;
-  for (int i = 0; (anAttr = a.lists[i]); i++) {
+  for (NSUInteger i = 0; (anAttr = a.lists[i]); i++) {
     OIDKeyValue *keyValue = anAttr->vals[0];
-
+    
     // Sanity check
-    if (keyValue->value.Length > data.length) return nil;
-
+    if (keyValue->value.Length > data.length) {
+      SecAsn1CoderRelease(coder);
+      return nil;
+    }
+    
     // Get the string value. First try creating as a UTF-8 string. If that fails,
     // fallback to trying as an ASCII string. If it still doesn't work, continue on
     // to the next value.
@@ -167,25 +172,26 @@
                                            encoding:NSASCIIStringEncoding];
     }
     if (!valueString) continue;
-
+    
     // The OID is still encoded, so we need to decode it.
-    NSString *objectId = [self decodeOIDWithBytes:keyValue->oid.Data
-                                           length:keyValue->oid.Length];
-
+    NSString *objectId = [PBDERDecoder decodeOIDWithBytes:keyValue->oid.Data
+                                                   length:keyValue->oid.Length];
+    
     // Add to the dictionary
     dict[objectId] = valueString;
   }
-
+  
+  SecAsn1CoderRelease(coder);
   return dict;
 }
 
 
-/*
- Decodes an ASN.1 Object Identifier into a string separated by periods.
- See http://msdn.microsoft.com/en-us/library/bb540809(v=vs.85).aspx for
- details of the encoding.
-*/
-- (NSString *)decodeOIDWithBytes:(unsigned char *)bytes length:(NSUInteger)length {
+/**
+ * Decodes an ASN.1 Object Identifier into a string separated by periods.
+ * See http://msdn.microsoft.com/en-us/library/bb540809(v=vs.85).aspx for
+ * details of the encoding.
+ **/
++ (NSString *)decodeOIDWithBytes:(unsigned char *)bytes length:(NSUInteger)length {
   NSMutableArray *objectId = [NSMutableArray array];
   BOOL inVariableLengthByte = NO;
   NSUInteger variableLength = 0;
@@ -209,6 +215,7 @@
         variableLength += a;
         inVariableLengthByte = NO;
         [objectId addObject:@(variableLength)];
+        variableLength = 0;
       } else {
         [objectId addObject:@((NSUInteger)byte)];
       }


### PR DESCRIPTION
I've been having issues with PBDERDecoder failing to properly parse the `distinguishedNames` of an `NSURLProtectionSpace`, and instead mistakenly returning `nil`. After searching around, I believe PBDERDecoder was copied from `SNTDERDecoder` in https://github.com/google/santa/. I'm not having any issues with that code, however. There are a few subtle differences in those files that I believe are causing the parser failures. This PR simply copies over the code from `SNTDERDecoder`.