### PR TITLE
Update to cocoadialog and ds modules

### DIFF
--- a/gmacpyutil/gmacpyutil/cocoadialog.py
+++ b/gmacpyutil/gmacpyutil/cocoadialog.py
@@ -319,27 +319,20 @@ class MsgBox(TweakDialog):
     return super_cmds
 
 
-class OK_MsgBox(TweakDialog):
+class OK_MsgBox(MsgBox):
   """ok-msgbox base class."""
 
+  # Disable buttons - not supported by this cocoadialog run mode.
+  GetButton1 = None
+  SetButton1 = None
+  GetButton2 = None
+  SetButton2 = None
+  GetButton3 = None
+  SetButton3 = None
+
   def __init__(self, title=None):
-    self._informative_text = None
-    self._float = True
     self._no_cancel = False
     super(OK_MsgBox, self).__init__(title)
-
-  def GetInformativeText(self):
-    return self._informative_text
-
-  def SetInformativeText(self, value):
-    value = value.replace('\n', chr(13))
-    self._informative_text = value
-
-  def GetFloat(self):
-    return self._float
-
-  def SetFloat(self, value):
-    self._float = value
 
   def GetNoCancel(self):
     return self._no_cancel
@@ -347,44 +340,31 @@ class OK_MsgBox(TweakDialog):
   def SetNoCancel(self):
     self._no_cancel = True
 
-  informative_text = property(GetInformativeText, SetInformativeText)
-  float = property(GetFloat, SetFloat)
   no_cancel = property(GetNoCancel, SetNoCancel)
 
   def GenerateCommand(self):
     super_cmds = super(OK_MsgBox, self).GenerateCommand()
     cmds = []
-    if self._informative_text:
-      cmds.extend(['--informative-text', self._informative_text])
-    if self._float:
-      cmds.append('--float')
     if self._no_cancel:
-      cmds.extend(['--no-cancel'])
+      cmds.append('--no-cancel')
     super_cmds.extend(cmds)
     return super_cmds
 
 
-class YesNo_MsgBox(TweakDialog):
+class YesNo_MsgBox(MsgBox):
   """yesno-msgbox base class."""
 
+  # Disable buttons - not supported by this cocoadialog run mode.
+  GetButton1 = None
+  SetButton1 = None
+  GetButton2 = None
+  SetButton2 = None
+  GetButton3 = None
+  SetButton3 = None
+
   def __init__(self, title=None):
-    self._informative_text = None
-    self._float = True
     self._no_cancel = False
     super(YesNo_MsgBox, self).__init__(title)
-
-  def GetInformativeText(self):
-    return self._informative_text
-
-  def SetInformativeText(self, value):
-    value = value.replace('\n', chr(13))
-    self._informative_text = value
-
-  def GetFloat(self):
-    return self._float
-
-  def SetFloat(self, value):
-    self._float = value
 
   def GetNoCancel(self):
     return self._no_cancel
@@ -392,19 +372,13 @@ class YesNo_MsgBox(TweakDialog):
   def SetNoCancel(self):
     self._no_cancel = True
 
-  informative_text = property(GetInformativeText, SetInformativeText)
-  float = property(GetFloat, SetFloat)
   no_cancel = property(GetNoCancel, SetNoCancel)
 
   def GenerateCommand(self):
     super_cmds = super(YesNo_MsgBox, self).GenerateCommand()
     cmds = []
-    if self._informative_text:
-      cmds.extend(['--informative-text', self._informative_text])
-    if self._float:
-      cmds.append('--float')
     if self._no_cancel:
-      cmds.extend(['--no-cancel'])
+      cmds.append('--no-cancel')
     super_cmds.extend(cmds)
     return super_cmds
 
@@ -504,6 +478,14 @@ class DropDown(MsgBox):
 class Standard_DropDown(MsgBox):  # pylint: disable=invalid-name
   """Generate a basic dropdown with Cancel and OK buttons."""
 
+  # Disable buttons - not supported by this cocoadialog run mode.
+  GetButton1 = None
+  SetButton1 = None
+  GetButton2 = None
+  SetButton2 = None
+  GetButton3 = None
+  SetButton3 = None
+
   def __init__(self, title=None, cocoadialog=None):
     self._items = []
     if cocoadialog:
@@ -544,6 +526,6 @@ class Standard_DropDown(MsgBox):  # pylint: disable=invalid-name
         dropdown_items.append(item)
       cmds.extend(dropdown_items)
     if self._no_cancel:
-      cmds.extend(['--no-cancel'])
+      cmds.append('--no-cancel')
     super_cmds.extend(cmds)
     return super_cmds

--- a/gmacpyutil/gmacpyutil/cocoadialog.py
+++ b/gmacpyutil/gmacpyutil/cocoadialog.py
@@ -266,12 +266,6 @@ class MsgBox(TweakDialog):
     self._button3 = None
     super(MsgBox, self).__init__(title)
 
-  def GetText(self):
-    return self._text
-
-  def SetText(self, value):
-    self._text = value
-
   def GetInformativeText(self):
     return self._informative_text
 
@@ -303,7 +297,6 @@ class MsgBox(TweakDialog):
   def SetButton3(self, value):
     self._button3 = value
 
-  text = property(GetText, SetText)
   informative_text = property(GetInformativeText, SetInformativeText)
   float = property(GetFloat, SetFloat)
   button1 = property(GetButton1, SetButton1)
@@ -322,6 +315,96 @@ class MsgBox(TweakDialog):
       cmds.extend(['--informative-text', self._informative_text])
     if self._float:
       cmds.append('--float')
+    super_cmds.extend(cmds)
+    return super_cmds
+
+
+class OK_MsgBox(TweakDialog):
+  """ok-msgbox base class."""
+
+  def __init__(self, title=None):
+    self._informative_text = None
+    self._float = True
+    self._no_cancel = False
+    super(OK_MsgBox, self).__init__(title)
+
+  def GetInformativeText(self):
+    return self._informative_text
+
+  def SetInformativeText(self, value):
+    value = value.replace('\n', chr(13))
+    self._informative_text = value
+
+  def GetFloat(self):
+    return self._float
+
+  def SetFloat(self, value):
+    self._float = value
+
+  def GetNoCancel(self):
+    return self._no_cancel
+
+  def SetNoCancel(self):
+    self._no_cancel = True
+
+  informative_text = property(GetInformativeText, SetInformativeText)
+  float = property(GetFloat, SetFloat)
+  no_cancel = property(GetNoCancel, SetNoCancel)
+
+  def GenerateCommand(self):
+    super_cmds = super(OK_MsgBox, self).GenerateCommand()
+    cmds = []
+    if self._informative_text:
+      cmds.extend(['--informative-text', self._informative_text])
+    if self._float:
+      cmds.append('--float')
+    if self._no_cancel:
+      cmds.extend(['--no-cancel'])
+    super_cmds.extend(cmds)
+    return super_cmds
+
+
+class YesNo_MsgBox(TweakDialog):
+  """yesno-msgbox base class."""
+
+  def __init__(self, title=None):
+    self._informative_text = None
+    self._float = True
+    self._no_cancel = False
+    super(YesNo_MsgBox, self).__init__(title)
+
+  def GetInformativeText(self):
+    return self._informative_text
+
+  def SetInformativeText(self, value):
+    value = value.replace('\n', chr(13))
+    self._informative_text = value
+
+  def GetFloat(self):
+    return self._float
+
+  def SetFloat(self, value):
+    self._float = value
+
+  def GetNoCancel(self):
+    return self._no_cancel
+
+  def SetNoCancel(self):
+    self._no_cancel = True
+
+  informative_text = property(GetInformativeText, SetInformativeText)
+  float = property(GetFloat, SetFloat)
+  no_cancel = property(GetNoCancel, SetNoCancel)
+
+  def GenerateCommand(self):
+    super_cmds = super(YesNo_MsgBox, self).GenerateCommand()
+    cmds = []
+    if self._informative_text:
+      cmds.extend(['--informative-text', self._informative_text])
+    if self._float:
+      cmds.append('--float')
+    if self._no_cancel:
+      cmds.extend(['--no-cancel'])
     super_cmds.extend(cmds)
     return super_cmds
 
@@ -391,7 +474,7 @@ class DropDown(MsgBox):
       self._cocoadialog = _CD
     self._title = title
     self._debug = None
-    super(DropDown, self).__init__()
+    super(DropDown, self).__init__(title)
 
   def __str__(self):
     return 'CocoaDialog[%s] -- title: [%s]' % (self.__class__.__name__,
@@ -418,7 +501,7 @@ class DropDown(MsgBox):
     return super_cmds
 
 
-class Standard_DropDown(Dialog):  # pylint: disable=invalid-name
+class Standard_DropDown(MsgBox):  # pylint: disable=invalid-name
   """Generate a basic dropdown with Cancel and OK buttons."""
 
   def __init__(self, title=None, cocoadialog=None):
@@ -430,7 +513,7 @@ class Standard_DropDown(Dialog):  # pylint: disable=invalid-name
     self._title = title
     self._no_cancel = False
     self._debug = None
-    super(Standard_DropDown, self).__init__()
+    super(Standard_DropDown, self).__init__(title)
 
   def __str__(self):
     return 'CocoaDialog[%s] -- title: [%s]' % (self.__class__.__name__,

--- a/gmacpyutil/gmacpyutil/cocoadialog.py
+++ b/gmacpyutil/gmacpyutil/cocoadialog.py
@@ -337,8 +337,8 @@ class OK_MsgBox(MsgBox):
   def GetNoCancel(self):
     return self._no_cancel
 
-  def SetNoCancel(self):
-    self._no_cancel = True
+  def SetNoCancel(self, cancel=True):
+    self._no_cancel = cancel
 
   no_cancel = property(GetNoCancel, SetNoCancel)
 
@@ -369,8 +369,8 @@ class YesNo_MsgBox(MsgBox):
   def GetNoCancel(self):
     return self._no_cancel
 
-  def SetNoCancel(self):
-    self._no_cancel = True
+  def SetNoCancel(self, cancel=True):
+    self._no_cancel = cancel
 
   no_cancel = property(GetNoCancel, SetNoCancel)
 
@@ -413,8 +413,8 @@ class Standard_InputBox(Dialog):  # pylint: disable=invalid-name
   def GetNoCancel(self):
     return self._no_cancel
 
-  def SetNoCancel(self):
-    self._no_cancel = True
+  def SetNoCancel(self, cancel=True):
+    self._no_cancel = cancel
 
   informative_text = property(GetInformativeText, SetInformativeText)
   text = property(GetText, SetText)
@@ -510,8 +510,8 @@ class Standard_DropDown(MsgBox):  # pylint: disable=invalid-name
   def GetNoCancel(self):
     return self._no_cancel
 
-  def SetNoCancel(self):
-    self._no_cancel = True
+  def SetNoCancel(self, cancel=True):
+    self._no_cancel = cancel
 
   items = property(GetItems, SetItems)
   no_cancel = property(GetNoCancel, SetNoCancel)

--- a/gmacpyutil/gmacpyutil/ds.py
+++ b/gmacpyutil/gmacpyutil/ds.py
@@ -134,13 +134,14 @@ def EnsureContactsNodeAbsent(node):
     DeleteNodeFromContactsPath(node)
 
 
-def DSQuery(dstype, objectname, attribute=None):
+def DSQuery(dstype, objectname, attribute=None, node='.'):
   """DirectoryServices query.
 
   Args:
     dstype: The type of objects to query. user, group.
     objectname: the object to query.
     attribute: the optional attribute to query.
+    node: the node to query.
   Returns:
     If an attribute is specified, the value of the attribute. Otherwise, the
     entire plist.
@@ -148,7 +149,7 @@ def DSQuery(dstype, objectname, attribute=None):
     DSException: Cannot query DirectoryServices.
   """
   ds_path = '/%ss/%s' % (dstype.capitalize(), objectname)
-  cmd = [_DSCL, '-plist', '.', '-read', ds_path]
+  cmd = [_DSCL, '-plist', node, '-read', ds_path]
   if attribute:
     cmd.append(attribute)
   (stdout, stderr, returncode) = gmacpyutil.RunProcess(cmd)
@@ -298,28 +299,30 @@ def DSDelete(dstype, objectname, attribute=None, value=None):
                                                        stderr))
 
 
-def UserAttribute(username, attribute):
+def UserAttribute(username, attribute, node='.'):
   """Returns the requested DirectoryService attribute for this user.
 
   Args:
     username: the user to retrieve a value for.
     attribute: the attribute to retrieve.
+    node: the node to query.
   Returns:
     the value of the attribute.
   """
-  return DSQuery('user', username, attribute)
+  return DSQuery('user', username, attribute, node=node)
 
 
-def GroupAttribute(groupname, attribute):
+def GroupAttribute(groupname, attribute, node='.'):
   """Returns the requested DirectoryService attribute for this group.
 
   Args:
     groupname: the group to retrieve a value for.
     attribute: the attribute to retrieve.
+    node: the node to query.
   Returns:
     the value of the attribute.
   """
-  return DSQuery('group', groupname, attribute)
+  return DSQuery('group', groupname, attribute, node=node)
 
 
 def EditLocalGroup(action, recordtype, account, group):


### PR DESCRIPTION
cocoadialog:
- Removed unnecessary Get/SetText methods from MsgBox class (already in
superclass).
- Added OK_MsgBox and YesNo_MsgBox classes for cocoadialog's ok-msgbox
and yesno-msgbox commands.
- Fixed an issue when initializing DropDown or Standard_DropDown with a
'title' argument.
- Changed Standard_DropDown to subclass MsgBox as DropDown does.

ds:
- Changed UserAttribute and GroupAttribute to allow passing of node
argument.
- Updated DSQuery accordingly.
- Tests continue to work with no changes.