### PR TITLE
Allow cocoadialog to be executed in a non-blocking manner.

### DIFF
--- a/gmacpyutil/gmacpyutil/cocoadialog.py
+++ b/gmacpyutil/gmacpyutil/cocoadialog.py
@@ -123,6 +123,11 @@ class Dialog(object):
     (stdout, unused_stderr, unused_returncode) = gmacpyutil.RunProcess(cmd)
     return stdout
 
+  def ShowAndDetach(self):
+    """Displays the dialog and allows execution to continue."""
+    cmd = [unicode(i) for i in self.GenerateCommand()]
+    return gmacpyutil.RunProcessInBackground(cmd)
+
 
 class TweakDialog(Dialog):
   """This class is one that can be tweaked with icons, text-color etc."""

--- a/gmacpyutil/gmacpyutil/gmacpyutil.py
+++ b/gmacpyutil/gmacpyutil/gmacpyutil.py
@@ -227,9 +227,9 @@ def _RunProcess(cmd, stdinput=None, env=None, cwd=None, sudo=False,
   Returns:
     Tuple: two strings and an integer: (stdout, stderr, returncode);
     stdout/stderr may also be None. If the process is set to launch in
-    background mode, a tuple of (<subprocess.Popen object>, None, None) is
+    background mode, an instance of <subprocess.Popen object> is
     returned, in order to be able to read from its pipes *and* use poll() to
-    check when it is finished
+    check when it is finished.
   Raises:
     GmacpyutilException: If both stdinput and sudo_password are specified
     GmacpyutilException: If both sudo and background are specified


### PR DESCRIPTION
- Add a ShowAndDetach() method to the Dialog object which uses RunProcessInBackground().
- Correct inaccurate docstring describing the return value of _RunProcess when run in background.