### PR TITLE
Require minor version in Deprecation Notifier

### DIFF
--- a/deprecation_notifier/DeprecationNotifier/DNAppDelegate.m
+++ b/deprecation_notifier/DeprecationNotifier/DNAppDelegate.m
@@ -46,11 +46,12 @@ static NSString * const kRenotifyPeriodKey = @"RenotifyPeriod";
   NSArray *systemVersionArray = [systemVersion componentsSeparatedByString:@"."];
   NSArray *expectedVersionArray = [expectedVersion componentsSeparatedByString:@"."];
 
-  if (systemVersionArray.count < 2 || expectedVersionArray.count < 2) {
+  if (systemVersionArray.count < 3 || expectedVersionArray.count < 3) {
     NSLog(@"Exiting: Error, unable to properly determine system version or expected version");
     [NSApp terminate:nil];
   } else if (([expectedVersionArray[0] intValue] <= [systemVersionArray[0] intValue]) &&
-             ([expectedVersionArray[1] intValue] <= [systemVersionArray[1] intValue])) {
+             ([expectedVersionArray[1] intValue] <= [systemVersionArray[1] intValue]) &&
+             ([expectedVersionArray[2] intValue] <= [systemVersionArray[2] intValue])) {
     NSLog(@"Exiting: OS is already %@ or greater", expectedVersion);
     [NSApp terminate:nil];
   }

--- a/deprecation_notifier/DeprecationNotifier/DNAppDelegate.m
+++ b/deprecation_notifier/DeprecationNotifier/DNAppDelegate.m
@@ -42,16 +42,26 @@ static NSString * const kRenotifyPeriodKey = @"RenotifyPeriod";
   NSDictionary *systemVersionDictionary = [NSDictionary dictionaryWithContentsOfFile:
                                               @"/System/Library/CoreServices/SystemVersion.plist"];
   NSString *systemVersion = systemVersionDictionary[@"ProductVersion"];
-
+  
   NSArray *systemVersionArray = [systemVersion componentsSeparatedByString:@"."];
+  NSMutableArray *mutableSystemVersionArray = [NSMutableArray array];
+  [mutableSystemVersionArray addObjectsFromArray:systemVersionArray];
+  if (mutableSystemVersionArray.count == 2) {
+      [mutableSystemVersionArray addObject:@"0"];
+  }
   NSArray *expectedVersionArray = [expectedVersion componentsSeparatedByString:@"."];
-
-  if (systemVersionArray.count < 3 || expectedVersionArray.count < 3) {
+  NSMutableArray *mutableExpectedVersionArray = [NSMutableArray array];
+  [mutableExpectedVersionArray addObjectsFromArray:expectedVersionArray];
+  if (mutableExpectedVersionArray.count == 2) {
+    [mutableExpectedVersionArray addObject:@"0"];
+  }
+  
+  if (mutableSystemVersionArray.count < 3 || mutableExpectedVersionArray.count < 3) {
     NSLog(@"Exiting: Error, unable to properly determine system version or expected version");
     [NSApp terminate:nil];
-  } else if (([expectedVersionArray[0] intValue] <= [systemVersionArray[0] intValue]) &&
-             ([expectedVersionArray[1] intValue] <= [systemVersionArray[1] intValue]) &&
-             ([expectedVersionArray[2] intValue] <= [systemVersionArray[2] intValue])) {
+  } else if (([mutableExpectedVersionArray[0] intValue] <= [mutableSystemVersionArray[0] intValue]) &&
+             ([mutableExpectedVersionArray[1] intValue] <= [mutableSystemVersionArray[1] intValue]) &&
+             ([mutableExpectedVersionArray[2] intValue] <= [mutableSystemVersionArray[2] intValue])) {
     NSLog(@"Exiting: OS is already %@ or greater", expectedVersion);
     [NSApp terminate:nil];
   }

--- a/deprecation_notifier/DeprecationNotifier/DNAppDelegate.m
+++ b/deprecation_notifier/DeprecationNotifier/DNAppDelegate.m
@@ -44,24 +44,22 @@ static NSString * const kRenotifyPeriodKey = @"RenotifyPeriod";
   NSString *systemVersion = systemVersionDictionary[@"ProductVersion"];
   
   NSArray *systemVersionArray = [systemVersion componentsSeparatedByString:@"."];
-  NSMutableArray *mutableSystemVersionArray = [NSMutableArray array];
-  [mutableSystemVersionArray addObjectsFromArray:systemVersionArray];
-  if (mutableSystemVersionArray.count == 2) {
-      [mutableSystemVersionArray addObject:@"0"];
-  }
+  if (systemVersionArray.count == 2) {
+      systemVersionArray = [systemVersionArray arrayByAddingObject:@"0"];
+    }
+
   NSArray *expectedVersionArray = [expectedVersion componentsSeparatedByString:@"."];
-  NSMutableArray *mutableExpectedVersionArray = [NSMutableArray array];
-  [mutableExpectedVersionArray addObjectsFromArray:expectedVersionArray];
-  if (mutableExpectedVersionArray.count == 2) {
-    [mutableExpectedVersionArray addObject:@"0"];
+  if (expectedVersionArray.count == 2) {
+      expectedVersionArray = [expectedVersionArray arrayByAddingObject:@"0"];
   }
   
-  if (mutableSystemVersionArray.count < 3 || mutableExpectedVersionArray.count < 3) {
+    
+  if (systemVersionArray.count < 3 || expectedVersionArray.count < 3) {
     NSLog(@"Exiting: Error, unable to properly determine system version or expected version");
     [NSApp terminate:nil];
-  } else if (([mutableExpectedVersionArray[0] intValue] <= [mutableSystemVersionArray[0] intValue]) &&
-             ([mutableExpectedVersionArray[1] intValue] <= [mutableSystemVersionArray[1] intValue]) &&
-             ([mutableExpectedVersionArray[2] intValue] <= [mutableSystemVersionArray[2] intValue])) {
+  } else if (([expectedVersionArray[0] intValue] <= [systemVersionArray[0] intValue]) &&
+             ([expectedVersionArray[1] intValue] <= [systemVersionArray[1] intValue]) &&
+             ([expectedVersionArray[2] intValue] <= [systemVersionArray[2] intValue])) {
     NSLog(@"Exiting: OS is already %@ or greater", expectedVersion);
     [NSApp terminate:nil];
   }

--- a/deprecation_notifier/DeprecationNotifier/en.lproj/Localizable.strings
+++ b/deprecation_notifier/DeprecationNotifier/en.lproj/Localizable.strings
@@ -2,13 +2,13 @@
     Configuraration options for building DeprecationNotifier.
 */
 
-// The desired OS version. Should be major version only (e.g. 10.11)
-"expectedVersion" = "10.12";
+// The desired OS version. Should be major and minor version (e.g. 10.13.0)
+"expectedVersion" = "10.13.2";
 
 // The message shown to the user below the countdown timer. Can be up to 8 lines long.
 "deprecationMsg" = "Your computer is running a deprecated version of Mac OS X.
 
-Please upgrade to macOS 10.12 (Sierra) as soon as possible.";
+Please upgrade to macOS 10.13.2 (High Sierra) as soon as possible.";
 
 // The URL to open in the user's web browser, which is opened when they close the window.
 "instructionURL" = "https://megacorp.com/helpdesk/upgrade-instructions";

--- a/deprecation_notifier/DeprecationNotifier/en.lproj/Localizable.strings
+++ b/deprecation_notifier/DeprecationNotifier/en.lproj/Localizable.strings
@@ -2,7 +2,7 @@
     Configuraration options for building DeprecationNotifier.
 */
 
-// The desired OS version. Should be major and minor version (e.g. 10.13.0)
+// The desired OS version (e.g. 10.13 or 10.12.6)
 "expectedVersion" = "10.13.2";
 
 // The message shown to the user below the countdown timer. Can be up to 8 lines long.


### PR DESCRIPTION
PR to fix #67 

- Added array elements (`expectedVersionArray[2]` and `systemVersionArray[2]`) which are responsible for running OS minor version check-logic.
- Adds functionality to allow for minor versions in `expectedVersion`.
- Amended comment reflecting above change requirements.


Tested on macOS 10.13.2 using `10.13.0`, `10.13.1`, `10.13.2`, `10.13.3` as `expectedVersion`; all passed.