### PR TITLE
Fixing version comparison & adding support for build comparisons

### DIFF
--- a/deprecation_notifier/DeprecationNotifier/DeprecationNotifier-Info.plist
+++ b/deprecation_notifier/DeprecationNotifier/DeprecationNotifier-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4</string>
+	<string>1.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
This is both a bug fix and a new feature.

First the bug fix - here's an example situation:
- expectedVersion set to: 10.14.3
- systemVersion read as: 10.15.1

This logic: https://github.com/google/macops/blob/master/deprecation_notifier/DeprecationNotifier/DNAppDelegate.m#L60-L63

```
  } else if (([expectedVersionArray[0] intValue] <= [systemVersionArray[0] intValue]) &&
             ([expectedVersionArray[1] intValue] <= [systemVersionArray[1] intValue]) &&
             ([expectedVersionArray[2] intValue] <= [systemVersionArray[2] intValue])) {
    NSLog(@"Exiting: OS is already %@ or greater", expectedVersion);
```

10 <= 10: true
14 <= 15: true
3 <= 1: false

The comparison will fail when it shouldn't.

This PR includes better comparison logic.

It additionally adds support for a new optional Localizable string value: expectedBuilds

The value of this string should be a comma delimited string (no spaces) of allowed builds.

If the OS is detected to be exactly the expectedVersion, then:
- if no expectedBuilds is defined, Deprecation Notifier will determine the OS meets the requirement
- if expectedBuilds is defined, the system build is looked for in expectedBuilds - if and only if the build is present, then the OS meets the requirement

Use case: for environments that are supporting a major OS version which has now gone into Security Updates, Deprecation Notifier is unable to tell a "fully patched" OS version without looking at the build information.