### PR TITLE
Re-doing https://github.com/google/macops/pull/69/

### DIFF
--- a/deprecation_notifier/DeprecationNotifier/DNAppDelegate.m
+++ b/deprecation_notifier/DeprecationNotifier/DNAppDelegate.m
@@ -39,7 +39,6 @@ static NSString * const kRenotifyPeriodKey = @"RenotifyPeriod";
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
   NSString *expectedVersion = NSLocalizedString(@"expectedVersion", @"");
-  NSString *expectedBuildsStr = NSLocalizedString(@"expectedBuilds", @"");
   NSString *buildsKey = @"expectedBuilds";
   NSString *builds = NSLocalizedString(buildsKey, @"");
   NSSet *expectedBuilds = [NSSet setWithArray:[builds componentsSeparatedByString:@","]];
@@ -61,7 +60,7 @@ static NSString * const kRenotifyPeriodKey = @"RenotifyPeriod";
   }
 
   NSLog(@"Info: System version: %@ %@", systemVersion, systemBuild);
-  NSLog(@"Info: Expected version: %@ %@", expectedVersion, expectedBuildsStr);
+  NSLog(@"Info: Expected version: %@ %@", expectedVersion, builds);
   if ([expectedVersionArray isEqualToArray:systemVersionArray]) {
     NSLog(@"Checking: running OS is equal to %@, checking build version", expectedVersion);
     if (!expectedBuilds.count) {

--- a/deprecation_notifier/DeprecationNotifier/DNAppDelegate.m
+++ b/deprecation_notifier/DeprecationNotifier/DNAppDelegate.m
@@ -39,9 +39,16 @@ static NSString * const kRenotifyPeriodKey = @"RenotifyPeriod";
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
   NSString *expectedVersion = NSLocalizedString(@"expectedVersion", @"");
+  NSString *expectedBuildsStr = NSLocalizedString(@"expectedBuilds", @"");
+  NSString *buildsKey = @"expectedBuilds";
+  NSString *builds = NSLocalizedString(buildsKey, @"");
+  NSSet *expectedBuilds = [NSSet setWithArray:[builds componentsSeparatedByString:@","]];
+  if (!expectedBuilds.count || [expectedBuilds containsObject:buildsKey]) expectedBuilds = nil;
+
   NSDictionary *systemVersionDictionary = [NSDictionary dictionaryWithContentsOfFile:
                                               @"/System/Library/CoreServices/SystemVersion.plist"];
   NSString *systemVersion = systemVersionDictionary[@"ProductVersion"];
+  NSString *systemBuild = systemVersionDictionary[@"ProductBuildVersion"];
 
   NSArray *systemVersionArray = [systemVersion componentsSeparatedByString:@"."];
   if (systemVersionArray.count == 2) {
@@ -53,14 +60,25 @@ static NSString * const kRenotifyPeriodKey = @"RenotifyPeriod";
       expectedVersionArray = [expectedVersionArray arrayByAddingObject:@"0"];
   }
 
-
-  if (systemVersionArray.count < 3 || expectedVersionArray.count < 3) {
-    NSLog(@"Exiting: Error, unable to properly determine system version or expected version");
-    [NSApp terminate:nil];
-  } else if (([expectedVersionArray[0] intValue] <= [systemVersionArray[0] intValue]) &&
-             ([expectedVersionArray[1] intValue] <= [systemVersionArray[1] intValue]) &&
-             ([expectedVersionArray[2] intValue] <= [systemVersionArray[2] intValue])) {
-    NSLog(@"Exiting: OS is already %@ or greater", expectedVersion);
+  NSLog(@"Info: System version: %@ %@", systemVersion, systemBuild);
+  NSLog(@"Info: Expected version: %@ %@", expectedVersion, expectedBuildsStr);
+  if ([expectedVersionArray isEqualToArray:systemVersionArray]) {
+    NSLog(@"Checking: running OS is equal to %@, checking build version", expectedVersion);
+    if (!expectedBuilds.count) {
+      NSLog(@"Exiting: No preferred build, so considered equal");
+      [NSApp terminate:nil];
+    }
+    if ([expectedBuilds containsObject:systemBuild]) {
+      NSLog(@"Exiting: OS build is one of the expected builds %@", expectedBuilds);
+      [NSApp terminate:nil];
+    }
+    NSLog(@"Checking: OS build not found in expected builds %@", expectedBuilds);
+  } else if ([systemVersionArray[0] intValue] < [expectedVersionArray[0] intValue] ||
+            [systemVersionArray[1] intValue] < [expectedVersionArray[1] intValue] ||
+            [systemVersionArray[2] intValue] < [expectedVersionArray[2] intValue]) {
+    NSLog(@"Checking: OS build is lower than required");
+  } else {
+    NSLog(@"Exiting: OS build is greater than required");
     [NSApp terminate:nil];
   }
 

--- a/deprecation_notifier/DeprecationNotifier/DeprecationNotifier-Info.plist
+++ b/deprecation_notifier/DeprecationNotifier/DeprecationNotifier-Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4</string>
+	<string>1.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Forking pudquick's branch and then rebasing it on top of master was easier than trying to do a merge.

From the original PR (which can be ignored if this works out):

This is both a bug fix and a new feature.

First the bug fix - here's an example situation:

expectedVersion set to: 10.14.3
systemVersion read as: 10.15.1
This logic: https://github.com/google/macops/blob/master/deprecation_notifier/DeprecationNotifier/DNAppDelegate.m#L60-L63

```
  } else if (([expectedVersionArray[0] intValue] <= [systemVersionArray[0] intValue]) &&
             ([expectedVersionArray[1] intValue] <= [systemVersionArray[1] intValue]) &&
             ([expectedVersionArray[2] intValue] <= [systemVersionArray[2] intValue])) {
    NSLog(@"Exiting: OS is already %@ or greater", expectedVersion);
10 <= 10: true
14 <= 15: true
3 <= 1: false
```

The comparison will fail when it shouldn't.

This PR includes better comparison logic.

It additionally adds support for a new optional Localizable string value: expectedBuilds

The value of this string should be a comma delimited string (no spaces) of allowed builds.

If the OS is detected to be exactly the expectedVersion, then:

- if no expectedBuilds is defined, Deprecation Notifier will determine the OS meets the requirement
- if expectedBuilds is defined, the system build is looked for in expectedBuilds - if and only if the build is present, then the OS meets the requirement

Use case: for environments that are supporting a major OS version which has now gone into Security Updates, Deprecation Notifier is unable to tell a "fully patched" OS version without looking at the build information.

